### PR TITLE
Included person in the shapes class

### DIFF
--- a/shape_segmentation/shapes_2023.yaml
+++ b/shape_segmentation/shapes_2023.yaml
@@ -1,7 +1,8 @@
 # This is the config file for training yolov8.
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
-path: /home/ws/uavf_2024/imaging_training_2024/shape_detection/tiny_example_dataset  # dataset root dir
+#path: /home/ws/uavf_2024/imaging_training_2024/shape_detection/tiny_example_dataset  # dataset root dir
+path: /mnt/c/Users/kirva/Desktop/Project_Design/Project_UAV/godot-data-gen/data
 train: images/train  # train images (relative to 'path')
 val: images/validation  # val images (relative to 'path') 
 test: images/test # test images
@@ -16,3 +17,4 @@ names:
   5: pentagon
   6: star
   7: cross
+  8: person


### PR DESCRIPTION
The shape label was missing person in it.

Here is the screenshot of the shape model's training process:

![retrain_results](https://github.com/uci-uav-forge/imaging_training_2024/assets/110004681/cc7ba30d-88a2-4408-a582-21ca18d87d46)
![confusion_matrix](https://github.com/uci-uav-forge/imaging_training_2024/assets/110004681/d276034b-03f7-4b43-b2cb-5908b039b7ce)
![confusion_matrix_normalized](https://github.com/uci-uav-forge/imaging_training_2024/assets/110004681/eb08bacb-3bb5-4c6d-abdd-c66a4d713627)
![labels](https://github.com/uci-uav-forge/imaging_training_2024/assets/110004681/71740443-5a13-4de8-bc15-22672b2fdd1f)

I only saw afterwards how the person has significantly lower instances.. There was a previous run with a more balance dataset.