### PR TITLE
All Shapes to "Target"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ issac_to_yolo/sample_yolo_dataset
 # data
 /data*/*/
 YOLO_*/
+
+# IDE
+.idea/
+.vscode/

--- a/yolo_to_yolo/data_transformers.py
+++ b/yolo_to_yolo/data_transformers.py
@@ -1,0 +1,49 @@
+from abc import abstractmethod, ABC
+from typing import Iterable
+
+from .data_types import YoloImageData, YoloLabel
+
+
+class YoloDataTransformer(ABC):
+    """
+    Parent class for YOLO data transformations, e.g., augmentations, tiling, classname-mapping, etc.
+
+    Subclasses only need to implement the __call__ method.
+    """
+    @abstractmethod
+    def __call__(self, input_data: YoloImageData) -> Iterable[YoloImageData]:
+        """
+        Transforms one annotated, YOLO-formatted image into a sequence of them.
+
+        The one-to-many signature is to support sub-tiling or offline augmentation steps.
+        """
+        ...
+
+    def flat_apply(self, input_data: Iterable[YoloImageData]) -> Iterable[YoloImageData]:
+        """
+        Applies the transformation to each annotated, YOLO-formatted image, outputting a
+        possibly-longer sequence of them.
+        """
+        for datum in input_data:
+            yield from self(datum)
+
+
+class ShapeTargetsOnly(YoloDataTransformer):
+    """
+    Filters out non-shape labels and changes shape labels to 'target'
+    """
+
+    def __call__(self, input_data: YoloImageData) -> Iterable[YoloImageData]:
+        new_labels: list[YoloLabel] = []
+        for label in input_data.labels:
+            classname = label.classname.lower()
+            if self.include(classname):
+                new_label = YoloLabel(label.location, 'target')
+                new_labels.append(new_label)
+
+        yield YoloImageData(input_data.img_id, input_data.task, input_data.image, new_labels)
+
+    @staticmethod
+    def include(classname: str) -> bool:
+        return classname != 'background' and len(classname) > 1
+

--- a/yolo_to_yolo/yolo_data_pipeline.py
+++ b/yolo_to_yolo/yolo_data_pipeline.py
@@ -1,36 +1,12 @@
-from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Iterable
 
 from tqdm import tqdm
 
 from yolo_to_yolo.data_types import YoloImageData
+from yolo_to_yolo.data_transformers import ShapeTargetsOnly, YoloDataTransformer
 from yolo_to_yolo.yolo_io import YoloReader, YoloWriter
-from yolo_to_yolo.yolo_io_types import PredictionTask, Task
-
-
-class YoloDataTransformer(ABC):
-    """
-    Parent class for YOLO data transformations, e.g., augmentations, tiling, classname-mapping, etc.
-
-    Subclasses only need to implement the __call__ method.
-    """
-    @abstractmethod
-    def __call__(self, input_data: YoloImageData) -> Iterable[YoloImageData]:
-        """
-        Transforms one annotated, YOLO-formatted image into a sequence of them.
-
-        The one-to-many signature is to support sub-tiling or offline augmentation steps.
-        """
-        ...
-
-    def flat_apply(self, input_data: Iterable[YoloImageData]) -> Iterable[YoloImageData]:
-        """
-        Applies the transformation to each annotated, YOLO-formatted image, outputting a
-        possibly-longer sequence of them.
-        """
-        for datum in input_data:
-            yield from self(datum)
+from yolo_to_yolo.yolo_io_types import PredictionTask
 
 
 class YoloDataPipeline:
@@ -104,5 +80,5 @@ if __name__ == "__main__":
 
     pipeline.apply_to_dir(
         Path("/home/minh/Desktop/imaging_training_2024/data/YOLO_DATASET/DATASETv1"),
-        Path("/home/minh/Desktop/imaging_training_2024/data/YOLO_DATASET/DATASETv1_dummy")
+        Path("/home/minh/Desktop/imaging_training_2024/data/YOLO_DATASET/DATASETv1_processed")
     )


### PR DESCRIPTION
## Description 
- New `YoloDataTransformer` subclass to filter for shape labels only and convert them to "target".
- For use in first step of two-shot pipeline.
NOTE: This needs to be merged after #10 

## Issues
- Part of uci-uav-forge/uavf_2024#179