### PR TITLE
Improve yolo_io multiprocessing usage

### DIFF
--- a/merge_datasets.py
+++ b/merge_datasets.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         Path('/home/minh/Desktop/uavf_2024/imaging_training_2024/data/isaac_yolo_7671_all/data.yaml'),
     ]
     
-    datasets = map(lambda path: YoloReader(path, PredictionTask.DETECTION), dataset_paths)
+    datasets = [YoloReader(path, PredictionTask.DETECTION) for path in dataset_paths]
     
     output_dir = Path('/home/minh/Desktop/uavf_2024/imaging_training_2024/data/isaac_godot_merged/')
     

--- a/merge_datasets.py
+++ b/merge_datasets.py
@@ -9,12 +9,12 @@ from tqdm import tqdm
 # Functions in this module are broken down so we can reuse them selectively.
 
 
-def merge_readers(readers: Iterable[YoloReader]) -> Iterable[YoloImageData]:
+def merge_readers(readers: Iterable[YoloReader], multiprocess: bool = True) -> Iterable[YoloImageData]:
     """
     Sequentially yield images from multiple readers, adding a prefix to `img_id`.
     """
     for prefix, reader in enumerate(readers):
-        for data in reader.read():
+        for data in reader.read(multiprocess=multiprocess):
             yield YoloImageData(
                 img_id=f"{prefix}_{data.img_id}",
                 task=data.task,
@@ -38,7 +38,8 @@ def merge_reader_classes(readers: Iterable[YoloReader]) -> set[str]:
 def merge_datasets(
     readers: Iterable[YoloReader],
     output_dir: Path, 
-    prediction_task: PredictionTask = PredictionTask.DETECTION
+    prediction_task: PredictionTask = PredictionTask.DETECTION,
+    multiprocess: bool = True
 ) -> None:
     """
     Merge YOLO-formatted datasets from readers.
@@ -52,10 +53,11 @@ def merge_datasets(
     
     writer.write(
         tqdm(
-            merge_readers(readers),
+            merge_readers(readers, multiprocess=multiprocess),
             desc="Processing data",
             unit="images"
-        )
+        ),
+        multiprocess=multiprocess
     )
 
 
@@ -69,4 +71,4 @@ if __name__ == "__main__":
     
     output_dir = Path('/home/minh/Desktop/uavf_2024/imaging_training_2024/data/isaac_godot_merged/')
     
-    merge_datasets(datasets, output_dir)
+    merge_datasets(datasets, output_dir, multiprocess=True)

--- a/yolo_to_yolo/yolo_io.py
+++ b/yolo_to_yolo/yolo_io.py
@@ -62,7 +62,7 @@ class YoloReader:
         """
         Read the dataset with concurrency. Yields tuples of `(YoloImageData, Task)`.
         """
-        pool: multiprocessing.Pool = multiprocessing.Pool(self.num_workers)
+        pool = multiprocessing.Pool(self.num_workers)
 
         for task in tasks:
             images_dir, labels_dir = self.descriptor.get_image_and_labels_dirs(task)
@@ -162,7 +162,7 @@ class YoloWriter:
         self,
         data: Iterable[YoloImageData]
     ) -> None:
-        pool: multiprocessing.Pool = multiprocessing.Pool(self.num_workers)
+        pool = multiprocessing.Pool(self.num_workers)
         pool.imap_unordered(self._worker_task, data, chunksize=8)
 
         pool.close()

--- a/yolo_to_yolo/yolo_io.py
+++ b/yolo_to_yolo/yolo_io.py
@@ -1,6 +1,6 @@
 from itertools import repeat
 from pathlib import Path
-from typing import Callable, Iterable, Generator
+from typing import Iterable, Generator
 import multiprocessing
 
 import numpy as np

--- a/yolo_to_yolo/yolo_io.py
+++ b/yolo_to_yolo/yolo_io.py
@@ -194,19 +194,24 @@ class YoloWriter:
         """
         Worker task for writing image and labels files.
         """
-        img_id, task, image, labels = data
+        try:
+            img_id, task, image, labels = data
 
-        images_dir, labels_dir = self.descriptor.get_image_and_labels_dirs(task)
+            images_dir, labels_dir = self.descriptor.get_image_and_labels_dirs(task)
 
-        img_path = images_dir / f'{img_id}.png'
-        labels_path = labels_dir / f'{img_id}.txt'
+            img_path = images_dir / f'{img_id}.png'
+            labels_path = labels_dir / f'{img_id}.txt'
 
-        Image.fromarray(image).save(img_path)
+            Image.fromarray(image).save(img_path)
 
-        with open(labels_path, 'w') as f:
-            for label in labels:
-                f.write(self._format_label(label))
-                f.write('\n')
+            with open(labels_path, 'w') as f:
+                for label in labels:
+                    f.write(self._format_label(label))
+                    f.write('\n')
+                    
+        except Exception as e:
+            print(f"Error writing {img_id}: {e}")
+            
 
     def _format_label(self, label: YoloLabel) -> str:
         class_id = self.classname_map.get_class_id(label.classname)

--- a/yolo_to_yolo/yolo_io.py
+++ b/yolo_to_yolo/yolo_io.py
@@ -7,8 +7,8 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
-from yolo_to_yolo.data_types import YoloImageData, YoloLabel, YoloBbox, Point, YoloOutline
-from yolo_to_yolo.yolo_io_types import PredictionTask, DatasetDescriptor, YoloSubsetDirs, Task, ClassnameMap
+from .data_types import YoloImageData, YoloLabel, YoloBbox, Point, YoloOutline
+from .yolo_io_types import PredictionTask, DatasetDescriptor, YoloSubsetDirs, Task, ClassnameMap
 
 
 class YoloReader:


### PR DESCRIPTION
## Description
- Print out errors in worker tasks.
- Option to disable multiprocessing for easier debugging.
- Reader/writer use fewer processes each for better resource sharing.

